### PR TITLE
Prepare NuGet 0.0.2 release

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,31 @@
+name: Publish NuGet Package
+
+on:
+  push:
+    branches:
+      - nuget
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore CrudQL/CrudQL.sln
+
+      - name: Build solution
+        run: dotnet build CrudQL/CrudQL.sln --configuration Release --no-restore
+
+      - name: Pack service project
+        run: dotnet pack CrudQL/CrudQL.Service/CrudQL.Service.csproj --configuration Release --no-build --output out
+
+      - name: Publish package to NuGet
+        run: dotnet nuget push out/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate

--- a/CrudQL/CrudQL.Service/CrudQL.Service.csproj
+++ b/CrudQL/CrudQL.Service/CrudQL.Service.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>CrudQL.Service</PackageId>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <Authors>Eduardo Cunha</Authors>
     <RepositoryUrl>https://github.com/eduardofacunha/CRUD-QL</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Add workflow to publish CrudQL.Service to NuGet when branch nuget updates
- Bump CrudQL.Service version to 0.0.2 for release validation

## Testing
- dotnet pack CrudQL/CrudQL.Service/CrudQL.Service.csproj -c Release -o out

## Deployment/Rollback
- Merge main into nuget to trigger publish workflow
- Roll back by reverting the release commit and deleting the published package if needed

Close #5