### PR TITLE
Fix NuGet workflow environment

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -8,8 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    environment: secrets
 
     steps:
       - uses: actions/checkout@v4
@@ -28,4 +27,6 @@ jobs:
         run: dotnet pack CrudQL/CrudQL.Service/CrudQL.Service.csproj --configuration Release --no-build --output out
 
       - name: Publish package to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: dotnet nuget push out/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate


### PR DESCRIPTION
## Summary
- Ensure publish job runs in the secrets environment so NuGet API key resolves

## Testing
- Pending: re-run workflow after merge to nuget

## Deployment/Rollback
- Merge main into nuget and observe successful publish
- Roll back by reverting commit if needed

Close #5