### PR TITLE
Automate v0.0.3 release workflow

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -9,13 +9,27 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: secrets
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Extract package version
+        id: package_version
+        run: |
+          version=$(grep -oPm1 '(?<=<Version>)[^<]+' CrudQL/CrudQL.Service/CrudQL.Service.csproj)
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "PACKAGE_VERSION=$version" >> $GITHUB_ENV
 
       - name: Restore dependencies
         run: dotnet restore CrudQL/CrudQL.sln
@@ -30,3 +44,36 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: dotnet nuget push out/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate
+
+      - name: Generate release notes
+        run: |
+          version="${PACKAGE_VERSION:-${{ steps.package_version.outputs.version }}}"
+          changes=$(git log origin/main..HEAD --pretty=format:'- %h %s' || true)
+          {
+            echo "Automated release for version v$version."
+            echo
+            echo "## Changes since main"
+            if [ -n "$changes" ]; then
+              printf '%s\n' "$changes"
+            else
+              echo "- No changes compared to main."
+            fi
+          } > release-notes.md
+
+      - name: Tag release
+        run: |
+          version="${{ steps.package_version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "v$version"
+          git push origin "refs/tags/v$version" --force
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.package_version.outputs.version }}
+          name: v${{ steps.package_version.outputs.version }}
+          body_path: release-notes.md
+          files: out/*.nupkg

--- a/CrudQL/CrudQL.Service/CrudQL.Service.csproj
+++ b/CrudQL/CrudQL.Service/CrudQL.Service.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>CrudQL.Service</PackageId>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>Eduardo Cunha</Authors>
     <RepositoryUrl>https://github.com/eduardofacunha/CRUD-QL</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Generate release notes and tag v0.0.3 automatically from nuget workflow
- Bump CrudQL.Service package version to 0.0.3

## Testing
- dotnet pack CrudQL/CrudQL.Service/CrudQL.Service.csproj -c Release -o out

## Deployment/Rollback
- Merge main into nuget to trigger publish workflow
- Roll back by reverting commit if needed

Close #5